### PR TITLE
Add python_requires flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ plugin_ignored_packages = []
 # Example:
 #     plugin_requires = ["someDependency==dev"]
 #     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
-additional_setup_parameters = {}
+additional_setup_parameters = {"python_requires": ">=3,<4"}
 
 ########################################################################################################################
 


### PR DESCRIPTION
Might help to avoid issues such as #25 #8, #18 and https://github.com/OctoPrint/plugins.octoprint.org/issues/794 as it will provide a sane error message about the problem.

I noticed [this comment](https://github.com/jamesmccannon02/OctoPrint-Tplinkautoshutdown/issues/25#issuecomment-784606482):
> Using the update tool is unreliable. It either works or it doesn't but this needs to be done in the next month if you still want to use octoprint as the owner of octoprint is fully removing all support next month

If you have issues with the update script, I fix them quickly... And to clarify on the Python support - there's currently no planned date for when Python 2 support will be dropped, it *will* be in OctoPrint 2.0 but that may not come before the end of 2021. 