### PR TITLE
Update readme with python-kasa transitive dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 This plugin is designed to help you integrate your IoT TP-Link Kasa wireless plug into OctoPrint. The basis of the plug-in is to enable you to automatically switch-off your 3D printer
 once a print has successfully completed.
 
+## Requirements
+* Python >=3.7, <4.0
+
 ## Setup
 
 Install via the bundled [Plugin Manager](https://docs.octoprint.org/en/master/bundledplugins/pluginmanager.html)

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -113,7 +113,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 
 
 __plugin_name__ = "TpLinkHandler"
-__plugin_pythoncompat__ = ">=3.0,<4"
+__plugin_pythoncompat__ = ">=3.7,<4"
 __plugin_implementation__ = TpLinkAutoShutdown()
 __plugin_hooks__ = {
 	"octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information


### PR DESCRIPTION
This might help someone else, python 3.6 is usually installed by default and is incompatible