### PR TITLE
Fix to deconflict with Pushover plugin

### DIFF
--- a/octoprint_TpLinkAutoShutdown/static/js/settingsControll.js
+++ b/octoprint_TpLinkAutoShutdown/static/js/settingsControll.js
@@ -7,7 +7,7 @@ window.onload = function() {
 
 document.getElementById("update").onclick = function update_info (){
     var address = document.getElementById("address").value;
-    var deviceType = document.getElementById("device").value;
+    var deviceType = document.getElementById("deviceType").value;
     OctoPrint.simpleApiCommand("TpLinkAutoShutdown", "update", {"url": address, "deviceType": deviceType})
         .done(function(responce){
             //console.log(responce.res.dev_name);

--- a/octoprint_TpLinkAutoShutdown/templates/TpNavigation_settings.jinja2
+++ b/octoprint_TpLinkAutoShutdown/templates/TpNavigation_settings.jinja2
@@ -16,7 +16,7 @@
     <div id="plugSettings">
         <p><b><u>Plug IP Address:</u></b></p>
         <input type="text"  id="address" class="input-box-level" data-bind="value: settings.plugins.TpLinkAutoShutdown.url">
-        <select name="DeviceType" id="device" data-bind="value: settings.plugins.TpLinkAutoShutdown.deviceType">
+        <select name="DeviceType" id="deviceType" data-bind="value: settings.plugins.TpLinkAutoShutdown.deviceType">
             <option value="smartPlug">Smart Plug</option>
             <option value="smartStrip">Smart Strip</option>
         </select>


### PR DESCRIPTION
"Fix" in v1.1.0 didn't actually resolve the conflict.  The name of the \<div> element for device type was causing the JavaScript getElementByID to return a null value because Pushover also has a \<div> named "device", and since it sorts higher than TPLinkHandler, it always loads first, if both plugins are installed.  This fix changes the ID of the \<div> element so that it doesn't conflict.

Tested with both plugins installed.