### PR TITLE
Sync power state with OctoPrint connection state

### DIFF
--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -102,11 +102,16 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 			# todo If Else dependent on the type of plug being used.
 			self._logger.info("Turning the printer ON")
 			self.conn.turnOn_btn()
+			self._printer.connect()
 			return flask.jsonify(res="Turning the 3D printer on. Please wait ... ")
 		elif command == "turnOff":
 			# todo Check the type of plug used
 			# todo If Else dependent on the type of plug being used.
+			if self._printer.is_printing() :
+				self._logger.info("Printer is busy")
+				return flask.jsonify(res="Cannot turn printer off.  Printer is busy")
 			self._logger.info("Turning the printer OFF")
+			self._printer.disconnect()
 			self.conn.shutdown_btn()
 			return flask.jsonify(res="Turning the 3D printer off. 3 ... 2 ... 1 ....")
 		# Triggered when the user clicks to 'update connection' within the settings interface

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -113,7 +113,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 			self._logger.info("Turning the printer OFF")
 			self._printer.disconnect()
 			self.conn.shutdown_btn()
-			return flask.jsonify(res="Turning the 3D printer off. 3 ... 2 ... 1 ....")
+			return flask.jsonify(res="")
 		# Triggered when the user clicks to 'update connection' within the settings interface
 		elif command == "update":
 			try:

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -4,6 +4,7 @@ from .TpLinkHandlerSmartPlug import TpLinkHandlerSmartPlug as wallPlug
 from .TpLinkHandlerSmartStrip import TpLinkHandlerSmartStrip as wallStrip
 import octoprint.plugin
 import flask
+from threading import Timer
 
 
 class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.SettingsPlugin,
@@ -95,6 +96,10 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 			update=["url", "deviceType"]
 		)
 
+	# Connect to the printer (executed after a timeout)
+	def connect_to_printer(self):
+		self._printer.connect()	
+
 	# Handling the requests sent from javascript
 	def on_api_command(self, command, data):
 		if command == "turnOn":
@@ -102,7 +107,8 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 			# todo If Else dependent on the type of plug being used.
 			self._logger.info("Turning the printer ON")
 			self.conn.turnOn_btn()
-			self._printer.connect()
+			t = Timer(2,self.connect_to_printer)
+			t.start()
 			return flask.jsonify(res="Turning the 3D printer on. Please wait ... ")
 		elif command == "turnOff":
 			# todo Check the type of plug used

--- a/octoprint_TpLinkAutoShutdown/static/js/navbarControll.js
+++ b/octoprint_TpLinkAutoShutdown/static/js/navbarControll.js
@@ -4,7 +4,7 @@ document.getElementById("turnOff").onclick = function turnOffPrinter() {
 
     if (conf == true) {
         OctoPrint.simpleApiCommand("TpLinkAutoShutdown", "turnOff", {"value" : "False"})
-            .done(function(responce) {});
+            .done(function(responce) {if (responce.res != "") alert(responce.res)});
     }else{
         console.log("Operation cancelled");
         alert("Operation cancelled");


### PR DESCRIPTION
Disconnect printer from OctoPrint before turning off
Connect printer to OctoPrint after turning on
Disable turning off when the printer is busy  (user should cancel print first)

This keeps the log from filling up with error messages when the printer is off.