### PR TITLE
Configuration to allow newer smart strips (HS300 specifically)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Although, this plugin may work with a number of other Kasa devices, this plugin 
 
 #### Smart Strips:
 * KP303
+* HS300
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Although, this plugin may work with a number of other Kasa devices, this plugin 
 * HS110
 
 #### Smart Strips:
-* KP303
 * HS300
+* KP303
 
 ## Authors
 

--- a/extras/TpLinkAutoShutdown.md
+++ b/extras/TpLinkAutoShutdown.md
@@ -99,6 +99,7 @@ Although, this plugin may work with a number of other Kasa devices, this plugin 
 * HS110
 
 #### Smart Strips:
+* KP300
 * KP303
 
 ## Authors

--- a/extras/TpLinkAutoShutdown.md
+++ b/extras/TpLinkAutoShutdown.md
@@ -99,7 +99,7 @@ Although, this plugin may work with a number of other Kasa devices, this plugin 
 * HS110
 
 #### Smart Strips:
-* KP300
+* HS300
 * KP303
 
 ## Authors

--- a/octoprint_TpLinkAutoShutdown/TpLinkHandlerSmartStrip.py
+++ b/octoprint_TpLinkAutoShutdown/TpLinkHandlerSmartStrip.py
@@ -24,6 +24,12 @@ class TpLinkHandlerSmartStrip(SmartDeviceException):
 			asyncio.create_task(self.device.children[1].turn_off())
 		if settings.get(["navButton", "deviceThree"]):
 			asyncio.create_task(self.device.children[2].turn_off())
+		if settings.get(["navButton", "deviceFour"]):
+			asyncio.create_task(self.device.children[3].turn_off())
+		if settings.get(["navButton", "deviceFive"]):
+			asyncio.create_task(self.device.children[4].turn_off())
+		if settings.get(["navButton", "deviceSix"]):
+			asyncio.create_task(self.device.children[5].turn_off())
 		return "shutdown"
 
 	def turnOn_btn(self, settings):
@@ -33,6 +39,12 @@ class TpLinkHandlerSmartStrip(SmartDeviceException):
 			asyncio.create_task(self.device.children[1].turn_on())
 		if settings.get(["navButton", "deviceThree"]):
 			asyncio.create_task(self.device.children[2].turn_on())
+		if settings.get(["navButton", "deviceFour"]):
+			asyncio.create_task(self.device.children[3].turn_on())
+		if settings.get(["navButton", "deviceFive"]):
+			asyncio.create_task(self.device.children[4].turn_on())
+		if settings.get(["navButton", "deviceSix"]):
+			asyncio.create_task(self.device.children[5].turn_on())
 		return "Turning on"
 
 	def turn_on(self, plugNumber):
@@ -46,3 +58,4 @@ class TpLinkHandlerSmartStrip(SmartDeviceException):
 
 	def __repr__(self):
 		pass
+	

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -190,7 +190,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					auto=False,
 					movieDone=False,
 				),
-    			deviceFour=dict(
+				deviceFour=dict(
 					light=False,
 					printer=False,
 					custom=False,

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -193,8 +193,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					light=False,
 					printer=False,
 					custom=False,
-					# test
-					auto=True,
+					auto=False,
 					movieDone=False,
 				),
 				deviceFour=dict(

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -187,7 +187,8 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					light=False,
 					printer=False,
 					custom=False,
-					auto=False,
+					#test
+					auto=True,
 					movieDone=False,
 				),
 				deviceFour=dict(

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -43,6 +43,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				self.conn.shutdown()
 		# If the plug being used is a smartStrip
 		# Children are zero indexed, contrary to documentation
+		# Added sockets for HS300 Support
 		elif self._settings.get(["deviceType"]) == "smartStrip":
 			# check the setting Preferences of each socket
 			if self._settings.get(["smartStrip", "deviceOne", "auto"]) and not self._settings.get(
@@ -57,9 +58,22 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					["smartStrip", "deviceThree", "movieDone"]):
 				self._logger.info("Socket three is being shutdown")
 				self.conn.shutdown(2)
+			if self._settings.get(["smartStrip", "deviceFour", "auto"]) and not self._settings.get(
+					["smartStrip", "deviceFour", "movieDone"]):
+				self._logger.info("Socket four is being shutdown")
+				self.conn.shutdown(0)
+			if self._settings.get(["smartStrip", "deviceFive", "auto"]) and not self._settings.get(
+					["smartStrip", "deviceFive", "movieDone"]):
+				self._logger.info("Socket five is being shutdown")
+				self.conn.shutdown(1)
+			if self._settings.get(["smartStrip", "deviceSix", "auto"]) and not self._settings.get(
+					["smartStrip", "deviceSix", "movieDone"]):
+				self._logger.info("Socket six is being shutdown")
+				self.conn.shutdown(2)
 
 	# Triggered through system events within the octoprint server
 	# noinspection PyArgumentList
+    #Updated for H300
 	def on_event(self, event, payload):
 		if event == "PrintDone":
 			self.plugHandler()
@@ -85,6 +99,12 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					self.conn.shutdown(1)
 				if self._settings.get(["smartStrip", "deviceThree", "movieDone"]) and self._settings.get(["smartStrip", "deviceThree", "auto"]):
 					self.conn.shutdown(2)
+				if self._settings.get(["smartStrip", "deviceFour", "movieDone"]) and self._settings.get(["smartStrip", "deviceFour", "auto"]):
+					self.conn.shutdown(3)
+				if self._settings.get(["smartStrip", "deviceFive", "movieDone"]) and self._settings.get(["smartStrip", "deviceFive", "auto"]):
+					self.conn.shutdown(4)
+				if self._settings.get(["smartStrip", "deviceSix", "movieDone"]) and self._settings.get(["smartStrip", "deviceSix", "auto"]):
+					self.conn.shutdown(5)
 		elif event == "PrintPaused":
 			self._logger.info("Print paused")
 
@@ -129,7 +149,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				return flask.jsonify(res=self.conn.get_plug_information())
 			except:
 				return flask.jsonify(res="Error Occurred")
-
+    	#Updated for HS300
 	def get_settings_defaults(self):
 		return dict(
 			url="0.0.0.0",
@@ -140,6 +160,9 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				deviceOne=True,
 				deviceTwo=True,
 				deviceThree=True,
+    			deviceFour=True,
+				deviceFive=True,
+				deviceSix=True,
 			),
 			smartPlug=dict(
 				auto=True,
@@ -161,6 +184,27 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					movieDone=False,
 				),
 				deviceThree=dict(
+					light=False,
+					printer=False,
+					custom=False,
+					auto=False,
+					movieDone=False,
+				),
+    			deviceFour=dict(
+					light=False,
+					printer=False,
+					custom=False,
+					auto=False,
+					movieDone=False,
+				),
+				deviceFive=dict(
+					light=False,
+					printer=False,
+					custom=False,
+					auto=False,
+					movieDone=False,
+				),
+				deviceSix=dict(
 					light=False,
 					printer=False,
 					custom=False,

--- a/octoprint_TpLinkAutoShutdown/__init__.py
+++ b/octoprint_TpLinkAutoShutdown/__init__.py
@@ -32,7 +32,6 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 		else:
 			self._logger.info("+++++++++++ Aborted on Startup connection +++++++++++")
 
-
 	def plugHandler(self):
 		# If the plug being used is a smartPlug
 		if self._settings.get(["deviceType"]) == "smartPlug":
@@ -61,19 +60,19 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 			if self._settings.get(["smartStrip", "deviceFour", "auto"]) and not self._settings.get(
 					["smartStrip", "deviceFour", "movieDone"]):
 				self._logger.info("Socket four is being shutdown")
-				self.conn.shutdown(0)
+				self.conn.shutdown(3)
 			if self._settings.get(["smartStrip", "deviceFive", "auto"]) and not self._settings.get(
 					["smartStrip", "deviceFive", "movieDone"]):
 				self._logger.info("Socket five is being shutdown")
-				self.conn.shutdown(1)
+				self.conn.shutdown(4)
 			if self._settings.get(["smartStrip", "deviceSix", "auto"]) and not self._settings.get(
 					["smartStrip", "deviceSix", "movieDone"]):
 				self._logger.info("Socket six is being shutdown")
-				self.conn.shutdown(2)
+				self.conn.shutdown(5)
 
 	# Triggered through system events within the octoprint server
 	# noinspection PyArgumentList
-    #Updated for H300
+	# Updated for H300
 	def on_event(self, event, payload):
 		if event == "PrintDone":
 			self.plugHandler()
@@ -93,17 +92,23 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				if self._settings.get(["smartPlug", "movieDone"]) and self._settings.get(["smartPlug", "auto"]):
 					self.conn.shutdown()
 			elif self._settings.get(["deviceType"]) == "smartStrip":
-				if self._settings.get(["smartStrip", "deviceOne", "movieDone"]) and self._settings.get(["smartStrip", "deviceOne", "auto"]):
+				if self._settings.get(["smartStrip", "deviceOne", "movieDone"]) and self._settings.get(
+						["smartStrip", "deviceOne", "auto"]):
 					self.conn.shutdown(0)
-				if self._settings.get(["smartStrip", "deviceTwo", "movieDone"]) and self._settings.get(["smartStrip", "deviceTwo", "auto"]):
+				if self._settings.get(["smartStrip", "deviceTwo", "movieDone"]) and self._settings.get(
+						["smartStrip", "deviceTwo", "auto"]):
 					self.conn.shutdown(1)
-				if self._settings.get(["smartStrip", "deviceThree", "movieDone"]) and self._settings.get(["smartStrip", "deviceThree", "auto"]):
+				if self._settings.get(["smartStrip", "deviceThree", "movieDone"]) and self._settings.get(
+						["smartStrip", "deviceThree", "auto"]):
 					self.conn.shutdown(2)
-				if self._settings.get(["smartStrip", "deviceFour", "movieDone"]) and self._settings.get(["smartStrip", "deviceFour", "auto"]):
+				if self._settings.get(["smartStrip", "deviceFour", "movieDone"]) and self._settings.get(
+						["smartStrip", "deviceFour", "auto"]):
 					self.conn.shutdown(3)
-				if self._settings.get(["smartStrip", "deviceFive", "movieDone"]) and self._settings.get(["smartStrip", "deviceFive", "auto"]):
+				if self._settings.get(["smartStrip", "deviceFive", "movieDone"]) and self._settings.get(
+						["smartStrip", "deviceFive", "auto"]):
 					self.conn.shutdown(4)
-				if self._settings.get(["smartStrip", "deviceSix", "movieDone"]) and self._settings.get(["smartStrip", "deviceSix", "auto"]):
+				if self._settings.get(["smartStrip", "deviceSix", "movieDone"]) and self._settings.get(
+						["smartStrip", "deviceSix", "auto"]):
 					self.conn.shutdown(5)
 		elif event == "PrintPaused":
 			self._logger.info("Print paused")
@@ -127,13 +132,13 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 			# todo If Else dependent on the type of plug being used.
 			self._logger.info("Turning the printer ON")
 			self.conn.turnOn_btn(self._settings)
-			t = Timer(2,self.connect_to_printer)
+			t = Timer(2, self.connect_to_printer)
 			t.start()
 			return flask.jsonify(res="Turning the 3D printer on. Please wait ... ")
 		elif command == "turnOff":
 			# todo Check the type of plug used
 			# todo If Else dependent on the type of plug being used.
-			if self._printer.is_printing() :
+			if self._printer.is_printing():
 				self._logger.info("Printer is busy")
 				return flask.jsonify(res="Cannot turn printer off.  Printer is busy")
 			self._logger.info("Turning the printer OFF")
@@ -149,7 +154,8 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				return flask.jsonify(res=self.conn.get_plug_information())
 			except:
 				return flask.jsonify(res="Error Occurred")
-    	#Updated for HS300
+
+	# Updated for HS300
 	def get_settings_defaults(self):
 		return dict(
 			url="0.0.0.0",
@@ -160,7 +166,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				deviceOne=True,
 				deviceTwo=True,
 				deviceThree=True,
-    			deviceFour=True,
+				deviceFour=True,
 				deviceFive=True,
 				deviceSix=True,
 			),
@@ -187,7 +193,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 					light=False,
 					printer=False,
 					custom=False,
-					#test
+					# test
 					auto=True,
 					movieDone=False,
 				),
@@ -251,6 +257,7 @@ class TpLinkAutoShutdown(octoprint.plugin.StartupPlugin, octoprint.plugin.Settin
 				pip="https://github.com/jamesmccannon02/OctoPrint-Tplinkautoshutdown/archive/{target_version}.zip"
 			)
 		)
+
 
 __plugin_name__ = "TpLinkHandler"
 __plugin_pythoncompat__ = ">=3.7,<4"

--- a/octoprint_TpLinkAutoShutdown/templates/TpNavigation_settings.jinja2
+++ b/octoprint_TpLinkAutoShutdown/templates/TpNavigation_settings.jinja2
@@ -86,6 +86,48 @@
                     <input type="checkbox" class="options_input_checkbox" id="movieDone" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceThree.movieDone"></label>
                 </td>
             </tr>
+                        <tr id="plugFour" class="stripTable">
+                <td class="stripTable">Socket Four</td>
+                <td class="stripTable">
+                    <label>Light <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFour.light"></label>
+                    <label>Printer <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFour.printer"></label>
+                    <label>Custom <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFour.custom"></label>
+                </td>
+                <td class="stripTable">
+                    <label class="options_input_label" for="autoMode">Auto-shutdown enabled
+                    <input type="checkbox" class="options_input_checkbox" id="autoMode" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFour.auto"></label>
+                    <label class="options_input_label" for="movieDone">Wait for timelapse to render
+                    <input type="checkbox" class="options_input_checkbox" id="movieDone" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFour.movieDone"></label>
+                </td>
+            </tr>
+            <tr id="plugFive" class="stripTable">
+                <td class="stripTable">Socket Five</td>
+                <td class="stripTable">
+                    <label>Light <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFive.light"></label>
+                    <label>Printer <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFive.printer"></label>
+                    <label>Custom <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFive.custom"></label>
+                </td>
+                <td class="stripTable">
+                    <label class="options_input_label" for="autoMode">Auto-shutdown enabled
+                    <input type="checkbox" class="options_input_checkbox" id="autoMode" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFive.auto"></label>
+                    <label class="options_input_label" for="movieDone">Wait for timelapse to render
+                    <input type="checkbox" class="options_input_checkbox" id="movieDone" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceFive.movieDone"></label>
+                </td>
+            </tr>
+            <tr id="plugSix" class="stripTable">
+                <td class="stripTable">Socket Six</td>
+                <td class="stripTable">
+                    <label>Light <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceSix.light"></label>
+                    <label>Printer <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceSix.printer"></label>
+                    <label>Custom <input type="checkbox" class="options_input_checkbox" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceSix.custom"></label>
+                </td>
+                <td class="stripTable">
+                    <label class="options_input_label" for="autoMode">Auto-shutdown enabled
+                    <input type="checkbox" class="options_input_checkbox" id="autoMode" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceSix.auto"></label>
+                    <label class="options_input_label" for="movieDone">Wait for timelapse to render
+                    <input type="checkbox" class="options_input_checkbox" id="movieDone" data-bind="checked: settings.plugins.TpLinkAutoShutdown.smartStrip.deviceSix.movieDone"></label>
+                </td>
+            </tr>
         </table>
     </div>
     <div id="btnControl">
@@ -99,6 +141,15 @@
             </label>
             <label class="checkbox inline">
               <input type="checkbox" id="inlineCheckbox3" data-bind="checked: settings.plugins.TpLinkAutoShutdown.navButton.deviceThree"> Plug three
+            </label>
+            <label class="checkbox inline">
+              <input type="checkbox" id="inlineCheckbox4" data-bind="checked: settings.plugins.TpLinkAutoShutdown.navButton.deviceFour"> Plug four
+            </label>
+            <label class="checkbox inline">
+              <input type="checkbox" id="inlineCheckbox5" data-bind="checked: settings.plugins.TpLinkAutoShutdown.navButton.deviceFive"> Plug five
+            </label>
+            <label class="checkbox inline">
+              <input type="checkbox" id="inlineCheckbox6" data-bind="checked: settings.plugins.TpLinkAutoShutdown.navButton.deviceSix"> Plug six
             </label>
         </form>
     </div>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "OctoPrint-Tplinkautoshutdown"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 
-plugin_version = "1.2.0"
+plugin_version = "1.3.0"
 
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin


### PR DESCRIPTION
I did not add additional functionality per se, only the ability to see and configure sockets on the HS300 (and presumably other >3 socket Kasa strips). 
Tested functionality running:
- python-kasa => 0.4.0dev3
- OctoPrint 1.7.0rc3
- Python 3.7.3
- OctoPi 0.18.0.0

 I did not regression test against other smartstrips (I only have the HS300).